### PR TITLE
Fix: Updated ugc_post_id parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_linkedin_pages_source v0.1.2
+## 🐞 Bugfix 🐞
+- Modified the `ugc_post_id` parsing logic within `stg_linkedin_pages__organization_ugc_post` to dynamically parse the correct `ugc_post_id`. Previously, only posts of the `share` type where being parsed correctly. This will now work for both `share` and `ugcpost` types ([#7](https://github.com/fivetran/dbt_linkedin_pages_source/issues/6))
 # dbt_linkedin_pages_source v0.1.1
 ## 🐞 Bugfix 🐞
 Previously, Redshift threw the error "constant expressions are not supported in partition by clauses" for the model `int_linkedin_pages__latest_post_history`. 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'linkedin_pages_source'
-version: '0.1.1'
+version: '0.1.2'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/models/stg_linkedin_pages__organization_ugc_post.sql
+++ b/models/stg_linkedin_pages__organization_ugc_post.sql
@@ -29,7 +29,7 @@ final as (
     select 
         _fivetran_synced,
         organization_id,
-        replace(ugc_post_id, 'urn:li:share:', '') as ugc_post_id,
+        split_part(ugc_post_id, ':', -1) as ugc_post_id,
         source_relation
     from fields
 )

--- a/models/stg_linkedin_pages__organization_ugc_post.sql
+++ b/models/stg_linkedin_pages__organization_ugc_post.sql
@@ -29,7 +29,15 @@ final as (
     select 
         _fivetran_synced,
         organization_id,
-        split_part(ugc_post_id, ':', -1) as ugc_post_id,
+
+        case
+            when lower(ugc_post_id) like '%urn:li:share:%' 
+                then replace(ugc_post_id, 'urn:li:share:', '')
+            when lower(ugc_post_id) like '%urn:li:ugcpost:%'
+                then replace(lower(ugc_post_id), 'urn:li:ugcpost:', '')
+            else ugc_post_id
+        end as ugc_post_id,
+
         source_relation
     from fields
 )


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Brandon Thomson, Analytics Engineer @ dbt Labs

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
This PR updates the `ugc_post_id` parsing logic within the `stg_linkedin_pages__organization_ugc_post` model. This logic previously only accounted for `share` type posts, and as a result downstream joins were breaking.


**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

While this PR doesn't introduce a breaking change, it will result in more accurate data in downstream tables, including `linkedin_pages__posts`.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature https://github.com/fivetran/dbt_linkedin_pages_source/issues/6
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

Tested changes in my local repo. Test outputs below:
![image](https://user-images.githubusercontent.com/16456253/157310876-2ddd34a8-7f1e-4acc-9c66-1e739e8c27e7.png)


**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🤠 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
